### PR TITLE
fix_データ送信でのエラーの改善（多分治った）

### DIFF
--- a/www/news.py
+++ b/www/news.py
@@ -18,11 +18,11 @@ def push_news_data(keyword):
     news_data = {}
     data = {}
     # 最初の日時　データの振り分けの際に利用するチェックデータ
-    check_time = datetime.datetime.fromisoformat(headlines['articles'][0]['publishedAt'].replace('Z', ''))
     if not headlines['articles']:
         # 記事が見つからない場合
         print("記事は見つかりませんでした")
     else:
+        check_time = datetime.datetime.fromisoformat(headlines['articles'][0]['publishedAt'].replace('Z', ''))
         # 帰ってきたデータのそれぞれのkeyを表示
         #print(headlines['articles'][0].keys())
         # 取得したニュースの全てを表示
@@ -48,35 +48,16 @@ if __name__ == "__main__":
     # クライアントを初期化
     newsapi = NewsApiClient(api_key='e79240c2cdf64ef8860194efcbb65ca0')
 
-    #トップニュースを取得
-    #headlines = newsapi.get_top_headlines(q='テスト')
-
-    # 過去のニュースを取得
-    headlines = newsapi.get_everything(q='テスト',sort_by='publishedAt',page_size=80)
-
-    # フロント側が欲しいデータの形
-    data_kari = {
-            '2018-12-01': {"art": ["詳細記事", "詳細記事"]},
-            '2018-12-02': {"art": ["gras", "fas"]},
-            '2018-12-03': {"art": ["gra", "fas"]}, }
-    print(data_kari)
-
+    headlines = newsapi.get_everything(q='テスト  　ーssdsf',sort_by='publishedAt',page_size=100)
     news_list = []
     news_data = {}
     data = {}
     # 最初の日時　データの振り分けの際に利用するチェックデータ
-    check_time = datetime.datetime.fromisoformat(headlines['articles'][0]['publishedAt'].replace('Z', ''))
     if not headlines['articles']:
         # 記事が見つからない場合
         print("記事は見つかりませんでした")
     else:
-        # 帰ってきたデータのそれぞれのkeyを表示
-        #print(headlines['articles'][0].keys())
-        # 取得したニュースの全てを表示
-        #print(headlines['articles'])
-        # 一番最初の記事の日時を取得
-        #print(headlines['articles'][0]['publishedAt'])
-
+        check_time = datetime.datetime.fromisoformat(headlines['articles'][0]['publishedAt'].replace('Z', ''))
         # 記事一つ一つ確認していいく
         for news in headlines['articles']:
         


### PR DESCRIPTION
エラーの原因が
`check_time = datetime.datetime.fromisoformat(headlines['articles'][0]['publishedAt'].replace('Z', ''))`
の位置にあったかもしれないので一応修正
検索結果が０軒である場合、上の処理はエラーを吐いてしまうので、これが原因だった？